### PR TITLE
add logging in pythonw env and fix connection drops with it

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -20,6 +20,10 @@ import zipfile
 import SimpleHTTPServer
 import SocketServer
 
+if sys.executable.endswith("pythonw.exe"):
+    sys.stdout = open(os.path.join(os.getenv("TEMP"), os.path.basename(sys.argv[0]))+".out.log", "wb");
+    sys.stderr = open(os.path.join(os.getenv("TEMP"), os.path.basename(sys.argv[0]))+".err.log", "wb")
+
 AGENT_VERSION = "0.4"
 AGENT_FEATURES = [
     "execpy", "pinning",

--- a/agent.py
+++ b/agent.py
@@ -20,9 +20,8 @@ import zipfile
 import SimpleHTTPServer
 import SocketServer
 
-if sys.executable.endswith("pythonw.exe"):
-    sys.stdout = open(os.path.join(os.getenv("TEMP"), os.path.basename(sys.argv[0]))+".out.log", "wb");
-    sys.stderr = open(os.path.join(os.getenv("TEMP"), os.path.basename(sys.argv[0]))+".err.log", "wb")
+sys.stdout = open(os.path.join(os.getenv("TEMP")) + "out.log", "wb");
+sys.stderr = open(os.path.join(os.getenv("TEMP")) + "err.log", "wb")
 
 AGENT_VERSION = "0.4"
 AGENT_FEATURES = [


### PR DESCRIPTION
Long debugged error which caused much misery :)

Anyways stderr (and also stdout) needs some sort of env which is set to `None` in pythonw.exe ... this however causes weird anomalies while talking to agent :/

This is one solution to fix this issue - there are probably more ways to handle that but as far as I tested then this works.
