### PR TITLE
Allow status POST to /status from localhost after pinning

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -21,7 +21,7 @@ import zipfile
 import SimpleHTTPServer
 import SocketServer
 
-AGENT_VERSION = "0.9.1"
+AGENT_VERSION = "0.10"
 AGENT_FEATURES = [
     "execpy", "pinning", "logs", "largefile", "unicodepath",
 ]
@@ -96,7 +96,6 @@ class MiniHTTPServer(object):
         return register
 
     def handle(self, obj):
-
         if "client_ip" in state and request.client_ip != state["client_ip"]:
             if request.client_ip != "127.0.0.1":
                 return

--- a/agent.py
+++ b/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (C) 2015-2017 Cuckoo Foundation.
+# Copyright (C) 2015-2019 Cuckoo Foundation.
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
@@ -36,9 +36,9 @@ class MiniHTTPRequestHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
         request.client_ip, request.client_port = self.client_address
         request.form = {}
         request.files = {}
+        request.method = "GET"
 
-        if "client_ip" not in state or request.client_ip == state["client_ip"]:
-            self.httpd.handle(self)
+        self.httpd.handle(self)
 
     def do_POST(self):
         environ = {
@@ -53,6 +53,7 @@ class MiniHTTPRequestHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
         request.client_ip, request.client_port = self.client_address
         request.form = {}
         request.files = {}
+        request.method = "POST"
 
         # Another pretty fancy workaround. Since we provide backwards
         # compatibility with the Old Agent we will get an xmlrpc request
@@ -68,8 +69,7 @@ class MiniHTTPRequestHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
                 else:
                     request.form[key] = value.value.decode("utf8")
 
-        if "client_ip" not in state or request.client_ip == state["client_ip"]:
-            self.httpd.handle(self)
+        self.httpd.handle(self)
 
 class MiniHTTPServer(object):
     def __init__(self):
@@ -96,6 +96,13 @@ class MiniHTTPServer(object):
         return register
 
     def handle(self, obj):
+
+        if "client_ip" in state and request.client_ip != state["client_ip"]:
+            if request.client_ip != "127.0.0.1":
+                return
+            if obj.path != "/status" or request.method != "POST":
+                return
+
         for route, fn in self.routes[obj.command]:
             if route.match(obj.path):
                 ret = fn()
@@ -166,6 +173,7 @@ class request(object):
     files = {}
     client_ip = None
     client_port = None
+    method = None
     environ = {
         "werkzeug.server.shutdown": lambda: app.shutdown(),
     }

--- a/agent.py
+++ b/agent.py
@@ -21,7 +21,7 @@ import zipfile
 import SimpleHTTPServer
 import SocketServer
 
-AGENT_VERSION = "0.9"
+AGENT_VERSION = "0.9.1"
 AGENT_FEATURES = [
     "execpy", "pinning", "logs", "largefile", "unicodepath",
 ]


### PR DESCRIPTION
The Cuckoo analyzer uses POST /status to inform the Cuckoo host the
analyzer has stopped or an exception that could not be logged has occured.
After implementing IP pinning for POST requests, this was no longer
possible. This change adds an IP pinning check exception if the request is
a POST request to /status and the origin is 127.0.0.1